### PR TITLE
Remove unnecessary dynamic library copy at `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,9 @@ FROM gcr.io/distroless/base-debian12:nonroot
 # Copy device plugin binary
 WORKDIR /
 
-# Below dynamic libraries are required.
-# $ ldd /main
-#     libfuriosa_smi.so => /lib/x86_64-linux-gnu/libfuriosa_smi.so (0x00007fffff4b0000)
-#     libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fffff2cf000)
-#     libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fffff2af000)
-#     libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fffff1d0000)
-#     /lib64/ld-linux-x86-64.so.2 (0x00007ffffffcc000)
+# Below dynamic libraries are required due to `furiosa-smi` and Rust dependencies.
 COPY --from=build /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so
-COPY --from=build /usr/lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/libc.so.6
 COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
-COPY --from=build /usr/lib/x86_64-linux-gnu/libm.so.6 /usr/lib/x86_64-linux-gnu/libm.so.6
 
 COPY --from=build /main /main
 


### PR DESCRIPTION
### One line PR Description
Remove unnecessary dynamic library copy at `Dockerfile`.

### What type of PR is this?
/kind devops

### Special notes for reviewer
Only 2 dynamic libraries are copied due to `furiosa-smi` and Rust dependencies.
- See [this Slack thread](https://furiosa-ai.slack.com/archives/C06DMGWTULF/p1724466939359379?thread_ts=1724386060.028769&cid=C06DMGWTULF) for more details.