### PR TITLE
Add Grafana dashboard panel for `furiosa_npu_core_utilization`

### DIFF
--- a/deployments/grafana/npu-dashboard.json
+++ b/deployments/grafana/npu-dashboard.json
@@ -508,7 +508,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "furiosa_npu_core_utilization{kubernetes_node_name=~\"${node}\", core=~\"${core}\", device=~\"${device}\"}",
+          "expr": "furiosa_npu_core_utilization{kubernetes_node_name=~\"${node}\", device=~\"${device}\", core=~\"${core}\"}",
           "interval": "",
           "legendFormat": "{{kubernetes_node_name}}: {{device}}:{{core}}",
           "range": true,


### PR DESCRIPTION
### One line PR Description
Add Grafana dashboard panel for `furiosa_npu_core_utilization`

### What type of PR is this?
/kind feature

### Special notes for reviewer
- Related PR: #17

![Screenshot 2024-09-25 at 15 53 56](https://github.com/user-attachments/assets/af1cc83c-150d-4a9b-8b0b-9c2899bec5d0)
