### PR TITLE
Change github auth method of custom action for `furiosa-smi` preparation

### DIFF
--- a/.github/workflows/build-and-test-golang-project.yml
+++ b/.github/workflows/build-and-test-golang-project.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Prepare `furiosa-smi`
-        uses: furiosa-ai/furiosa-smi/actions/prepare@main
+        uses: furiosa-ai/furiosa-smi/actions/prepare@add-ssh-key-input-into-the-prepare-furiosa-smi-action
         with:
-          personal-access-token: '${{ secrets.TOKEN_FOR_CLONE_ANOTHER_REPO }}'
+          ssh-key: ${{ secrets.FURIOSA_SMI_RDONLY_DEPLOY_KEY }}
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v4


### PR DESCRIPTION
### One line PR Description
- resolve: furiosa-ai/cloud-native-toolkit#8

Use SSH Key authentiation rather than using PAT

### What type of PR is this?
/kind devops

### Special notes for reviewer
- Auth method has been change from PAT to SSH Key due to [this Slack thread](https://furiosa-ai.slack.com/archives/C06DMGWTULF/p1736920528433969?thread_ts=1733794668.408729&cid=C06DMGWTULF).