### PR TITLE
use os hostname when nodename argument is empty

### DIFF
--- a/internal/collector/metric_factory.go
+++ b/internal/collector/metric_factory.go
@@ -2,8 +2,10 @@ package collector
 
 import (
 	"fmt"
-	"github.com/furiosa-ai/furiosa-smi-go/pkg/smi"
+	"os"
 	"slices"
+
+	"github.com/furiosa-ai/furiosa-smi-go/pkg/smi"
 )
 
 type MetricFactory interface {
@@ -39,7 +41,13 @@ func (m *metricFactory) NewDeviceWiseMetric(d smi.Device) (Metric, error) {
 	metric[firmwareVersion] = info.firmwareVersion
 	metric[pertVersion] = info.pertVersion
 	metric[driverVersion] = m.driverVersion
-	metric[hostname] = m.nodeName
+	if m.nodeName != "" {
+		metric[hostname] = m.nodeName
+	} else if osHostname, err := os.Hostname(); err == nil {
+		metric[hostname] = osHostname
+	} else {
+		metric[hostname] = ""
+	}
 
 	return metric, nil
 }


### PR DESCRIPTION
### One line PR Description
[//]: # (If this PR references other issue, please paste that link into below `{ISSUE_LINK_HERE}` section and uncomment it.)
[//]: # (- resolve: {ISSUE_LINK_HERE})

This is PR to use os hostname when nodename argument is empty

### What type of PR is this?
[//]: # (Please add same label in your PR too.)

/kind bug

### Special notes for reviewer
